### PR TITLE
check that the attestation structure type is TPM_ST_ATTEST_CERTIFY

### DIFF
--- a/go/pkg/verifier/verifier.go
+++ b/go/pkg/verifier/verifier.go
@@ -217,6 +217,10 @@ func verifyAttest(attest *tpm2.TPMSAttest) error {
 		return fmt.Errorf("%w: unexpected prefix %0x", ErrInvalidAttestation, attest.Magic)
 	}
 
+	if attest.Type != tpm2.TPMSTAttestCertify {
+		return fmt.Errorf("%w: unexpected attestation type %0x", ErrInvalidAttestation, attest.Type)
+	}
+
 	// TODO: check qualified signer?
 
 	return nil


### PR DESCRIPTION
This change makes the example verifier a bit more complete by checking that the attestation structure type is as expected (TPM_ST_ATTEST_CERTIFY) as opposed to some other type of attestation signed by the HMAC key.